### PR TITLE
feat: support loading multiple icon sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,31 @@ inputs, as prefix icons or suffix icons, for example. You can also use the
 </template>
 ```
 
+### Using multiple icon sets
+
+You may reference icons from multiple icon sets in your FormKit inputs. To do so, load all the icon sets you need and pass them to the `createIconifyLoader` function and make
+sure to prefix the icon names with the icon set name.
+
+Here's an example where we load the Heroicons and the Majesticons icon sets.
+
+```ts
+import { icons as heroicons } from "@iconify-json/heroicons";
+import { icons as majesticons } from "@iconify-json/majesticons";
+import type { DefaultConfigOptions } from "@formkit/vue";
+import { createIconifyLoader } from "@hedger/formkit-iconify-loader";
+
+export const config = {
+	iconLoader: createIconifyLoader(heroicons, majesticons),
+} satisfies DefaultConfigOptions;
+```
+
+```html
+<template>
+	<FormKit type="email" prefix-icon="heroicons:envelope" />
+	<FormKitIcon icon="majesticons:academic-cap" />
+</template>
+```
+
 ## License
 
 Copyright © 2023, [Nicolas Hedger](https://github.com/nhedger). Released under the [MIT License](LICENSE.md).

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,35 @@ import type { FormKitIconLoader } from "@formkit/themes";
 import type { IconifyJSON } from "@iconify/types";
 import { getIconData, iconToSVG, iconToHTML, replaceIDs } from "@iconify/utils";
 
-export const createIconifyLoader = (icons: IconifyJSON): FormKitIconLoader => {
+export const createIconifyLoader = (
+	icons: IconifyJSON,
+	...moreIcons: IconifyJSON[]
+): FormKitIconLoader => {
 	return async (name: string) => {
-		// Retrieve the data for the icon
-		const iconData = getIconData(icons, name);
+		const allIcons = [icons, ...moreIcons];
+		let setName: string | undefined = undefined;
+		let iconName: string | undefined = undefined;
 
-		// If the icon doesn't exist, return undefined
+		// If the name of the icon include a colon, we split it into the set
+		// name and the icon name.
+		if (name.includes(":")) {
+			[setName, iconName] = name.split(":");
+		} else {
+			iconName = name;
+		}
+
+		// Try to find the set to which the icons belongs using the set name.
+		let set: IconifyJSON | undefined;
+		if (setName && iconName) {
+			set = allIcons.find((iconSet) => iconSet.prefix === setName);
+		}
+
+		// Retrieve the data for the icon from the set.
+		// Fallback to the first set if no set was found previously.
+		const iconData = getIconData(set || allIcons[0], iconName);
+
+		// At this point, if no icon data was found, we return undefined
+		// and no icon will be rendered.
 		if (!iconData) {
 			return undefined;
 		}


### PR DESCRIPTION
This PR adds support for loading icons from multiple icon sets.

Until now, the `createIconifyLoader` function only accepted a single parameter. You may now pass additional icon sets as extra parameters.

```ts
import { icons as heroicons } from "@iconify-json/heroicons";
import { icons as majesticons } from "@iconify-json/majesticons";
import { createIconifyLoader } from "@hedger/formkit-iconify-loader";

createIconifyLoader(heroicons, majesticons);
```

When using multiple icon sets, the icons of the first icon set do not need to be prefixed (but can be), but the icons from the following sets need to be prefixed.

Here's an example

```html
<template>
	<!-- Loaded from the heroicons set -->
	<FormKit type="email" prefix-icon="envelope" />

	<!-- Loaded from the majesticons set -->
	<FormKitIcon icon="majesticons:academic-cap" />
</template>
```